### PR TITLE
children may not be array

### DIFF
--- a/src/api/build-widget-tree.ts
+++ b/src/api/build-widget-tree.ts
@@ -21,7 +21,10 @@ export function buildWidgetTree(jsxTree: JSX.Element): WidgetTree {
   const { children, ...otherProps } = jsxTree.props;
 
   const updatedChildren =
-    jsxTree.type.processChildren?.(otherProps, children ?? []) ??
+    jsxTree.type.processChildren?.(
+      otherProps,
+      children ? (Array.isArray(children) ? children : [children]) : []
+    ) ??
     children ??
     [];
 


### PR DESCRIPTION
children may not be array if there is only one child in js. 

Solution:
Added a checking