### PR TITLE
feat: expose get widget info function

### DIFF
--- a/src/api/get-widget-info.ts
+++ b/src/api/get-widget-info.ts
@@ -1,0 +1,18 @@
+import { AndroidWidget } from '../AndroidWidget';
+
+export interface GetWidgetInfoProps {
+  /**
+   * The name of the widget to update
+   */
+  widgetName: string;
+}
+
+/**
+ * Request widget update for a given widget name
+ * A callback will be called for each widget with that name that is added to the home screen
+ *
+ * @param param0 {@link GetWidgetInfoProps}
+ */
+export async function getWidgetInfo({ widgetName }: GetWidgetInfoProps) {
+  return await AndroidWidget.getWidgetInfo(widgetName);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 export * from './api/register-widget-task-handler';
 export * from './api/request-widget-update';
+export * from './api/get-widget-info';
 export * from './api/types';
 export * from './api/WidgetPreview';
 export * from './config-plugin.type';


### PR DESCRIPTION
I would like to expose the function to getWidgetInfo because I want to start the android service only when a widget is installed. I can use getWidgetInfo to check if my widget is installed