### PR TITLE
feat: Add openApp

### DIFF
--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidget.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidget.java
@@ -127,6 +127,7 @@ public class RNWidget {
         intent.putExtra("widgetId", id);
         intent.putExtra("clickAction", clickableView.getClickAction());
         intent.putExtra("clickActionData", Arguments.toBundle(clickableView.getClickActionData()));
+        intent.putExtra("openApp", clickableView.getOpenApp());
         PendingIntent pendingIntent = PendingIntent.getBroadcast(
             appContext,
             (int) System.currentTimeMillis(),

--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidgetProvider.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidgetProvider.java
@@ -49,14 +49,14 @@ public class RNWidgetProvider extends AppWidgetProvider {
         String action = incomingIntent.hasExtra("widgetAction") ? incomingIntent.getStringExtra("widgetAction") : "WIDGET_CLICK";
         boolean openApp = incomingIntent.hasExtra("openApp") && incomingIntent.getBooleanExtra("openApp", false);
 
-//        if (openApp) {
-//            try {
-//                Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
-//                context.startActivity(launchIntent);
-//            } catch (Exception e) {
-//                e.printStackTrace();
-//            }
-//        } else {
+        if (openApp) {
+            try {
+                Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+                context.startActivity(launchIntent);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        } else {
             Intent backgroundTaskIntent = buildIntent(context, widgetId, action);
 
             if (incomingIntent.hasExtra("clickAction")) {
@@ -65,7 +65,7 @@ public class RNWidgetProvider extends AppWidgetProvider {
             }
 
             startBackgroundTask(context, backgroundTaskIntent);
-//        }
+        }
     }
 
     @Override

--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidgetProvider.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidgetProvider.java
@@ -47,15 +47,25 @@ public class RNWidgetProvider extends AppWidgetProvider {
 
         int widgetId = incomingIntent.getIntExtra("widgetId", -1);
         String action = incomingIntent.hasExtra("widgetAction") ? incomingIntent.getStringExtra("widgetAction") : "WIDGET_CLICK";
+        boolean openApp = incomingIntent.hasExtra("openApp") && incomingIntent.getBooleanExtra("openApp", false);
 
-        Intent backgroundTaskIntent = buildIntent(context, widgetId, action);
+//        if (openApp) {
+//            try {
+//                Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+//                context.startActivity(launchIntent);
+//            } catch (Exception e) {
+//                e.printStackTrace();
+//            }
+//        } else {
+            Intent backgroundTaskIntent = buildIntent(context, widgetId, action);
 
-        if (incomingIntent.hasExtra("clickAction")) {
-            backgroundTaskIntent.putExtra("clickAction", incomingIntent.getStringExtra("clickAction"));
-            backgroundTaskIntent.putExtra("clickActionData", incomingIntent.getBundleExtra("clickActionData"));
-        }
+            if (incomingIntent.hasExtra("clickAction")) {
+                backgroundTaskIntent.putExtra("clickAction", incomingIntent.getStringExtra("clickAction"));
+                backgroundTaskIntent.putExtra("clickActionData", incomingIntent.getBundleExtra("clickActionData"));
+            }
 
-        startBackgroundTask(context, backgroundTaskIntent);
+            startBackgroundTask(context, backgroundTaskIntent);
+//        }
     }
 
     @Override

--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidgetProvider.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidgetProvider.java
@@ -52,6 +52,9 @@ public class RNWidgetProvider extends AppWidgetProvider {
         if (openApp) {
             try {
                 Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+                if (incomingIntent.hasExtra("clickActionData")) {
+                    launchIntent.putExtra("clickActionData", incomingIntent.getBundleExtra("clickActionData"));
+                }
                 context.startActivity(launchIntent);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/android/src/main/java/com/reactnativeandroidwidget/builder/ClickableView.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/builder/ClickableView.java
@@ -8,11 +8,13 @@ public class ClickableView {
     private final View view;
     private final String clickAction;
     private final ReadableMap clickActionData;
+    private final boolean openApp;
 
-    public ClickableView(View view, String clickAction, ReadableMap clickActionData) {
+    public ClickableView(View view, String clickAction, ReadableMap clickActionData, boolean openApp) {
         this.view = view;
         this.clickAction = clickAction;
         this.clickActionData = clickActionData;
+        this.openApp = openApp;
     }
 
     public View getView() {
@@ -25,5 +27,9 @@ public class ClickableView {
 
     public ReadableMap getClickActionData() {
         return clickActionData;
+    }
+
+    public boolean getOpenApp() {
+        return openApp;
     }
 }

--- a/android/src/main/java/com/reactnativeandroidwidget/builder/WidgetFactory.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/builder/WidgetFactory.java
@@ -60,13 +60,15 @@ public class WidgetFactory {
     static View buildWidget(ReactApplicationContext context, ReadableMap config) throws Exception {
         BaseWidget<? extends View> baseWidget = getBaseWidget(context, config);
         View view = baseWidget.getView();
+        ReadableMap props = config.getMap("props");
 
-        if (config.getMap("props").hasKey("clickAction")) {
+        if (props.hasKey("clickAction") || props.hasKey("openApp")) {
             clickableViews.add(
                 new ClickableView(
                     view,
-                    config.getMap("props").getString("clickAction"),
-                    config.getMap("props").getMap("clickActionData")
+                    props.getString("clickAction"),
+                    props.getMap("clickActionData"),
+                    props.getBoolean("openApp")
                 )
             );
         }

--- a/android/src/main/java/com/reactnativeandroidwidget/builder/WidgetFactory.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/builder/WidgetFactory.java
@@ -68,7 +68,7 @@ public class WidgetFactory {
                     view,
                     props.getString("clickAction"),
                     props.getMap("clickActionData"),
-                    props.getBoolean("openApp")
+                    props.hasKey("openApp") && props.getBoolean("openApp")
                 )
             );
         }

--- a/docs/docs/get-clickactiondata-when-open-app.md
+++ b/docs/docs/get-clickactiondata-when-open-app.md
@@ -1,0 +1,185 @@
+---
+sidebar_position: 7
+sidebar_label: Get clickActionData when open app
+---
+
+# Get `clickActionData` when open app
+
+In `MainActivity.java`, add `import android.os.Bundle;` at import list on top.
+
+For React Native 0.71, add code below `DefaultNewArchitectureEntryPoint.getConcurrentReactEnabled()` line:
+
+```diff
+    return new DefaultReactActivityDelegate(
+        this,
+        getMainComponentName(),
+        // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+        DefaultNewArchitectureEntryPoint.getFabricEnabled(), // fabricEnabled
+        // If you opted-in for the New Architecture, we enable Concurrent React (i.e. React 18).
+        DefaultNewArchitectureEntryPoint.getConcurrentReactEnabled() // concurrentRootEnabled
+-   );
++   ) {
++       private Bundle mInitialProps = null;
++
++       @Override
++       protected void onCreate(Bundle savedInstanceState) {
++           Bundle bundle = getIntent().getExtras();
++           if (bundle != null && bundle.containsKey("clickActionData")) {
++               mInitialProps = new Bundle();
++               mInitialProps.putBundle("clickActionData", bundle.getBundle("clickActionData"));
++           }
++           super.onCreate(null);
++       }
++
++       @Override
++       protected Bundle getLaunchOptions() {
++           return mInitialProps;
++       }
++   };
+```
+
+For React Native 0.70 or below, add code below `return new MainActivityDelegate(this, getMainComponentName());` line:
+
+```diff
+-   return new MainActivityDelegate(this, getMainComponentName());
++   return new MainActivityDelegate(this, getMainComponentName()) {
++       private Bundle mInitialProps = null;
++
++       @Override
++       protected void onCreate(Bundle savedInstanceState) {
++           Bundle bundle = getIntent().getExtras();
++           if (bundle != null && bundle.containsKey("clickActionData")) {
++               mInitialProps = new Bundle();
++               mInitialProps.putBundle("clickActionData", bundle.getBundle("clickActionData"));
++           }
++           super.onCreate(null);
++       }
++
++       @Override
++       protected Bundle getLaunchOptions() {
++           return mInitialProps;
++       }
++   };
+```
+
+Now, at the root app, you can access data from its props.
+
+Example:
+
+```ts
+/// App.tsx
+
+type ExampleScreens = {
+  ListScreen: undefined;
+  FitnessWidgetPreviewScreen: undefined;
+  ResizableMusicWidgetPreviewScreen: undefined;
+  CounterScreen: undefined;
+};
+
+type Props = {
+  clickActionData: {
+    screenName: keyof ExampleScreens;
+  };
+};
+
+const Stack = createNativeStackNavigator<ExampleScreens>();
+
+export function App({ clickActionData }: Props) {
+  const navRef = useNavigationContainerRef<ExampleScreens>();
+  const [isReady, setIsReady] = useState(false);
+  console.log(clickActionData);
+
+  useEffect(() => {
+    // Navigate to `screenName` defined inside `clickActionData` of widget
+    if (isReady && clickActionData && navRef) {
+      navRef.navigate(clickActionData.screenName);
+    }
+  }, [clickActionData, isReady, navRef]);
+
+  return (
+    <NavigationContainer ref={navRef} onReady={() => setIsReady(true)}>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="ListScreen"
+          component={ListScreen}
+          options={{ title: 'React Native Android Widget Example' }}
+        />
+        <Stack.Screen
+          name="CounterScreen"
+          component={CounterScreen}
+          options={{ title: 'Counter Demo' }}
+        />
+        <Stack.Screen
+          name="FitnessWidgetPreviewScreen"
+          component={FitnessWidgetPreviewScreen}
+          options={{ title: 'Fitness Widget Preview' }}
+        />
+        <Stack.Screen
+          name="ResizableMusicWidgetPreviewScreen"
+          component={ResizableMusicWidgetPreviewScreen}
+          options={{ title: 'Resizable Music Widget Preview' }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+```
+
+```ts
+/// Widget.tsx
+
+import React from 'react';
+import { FlexWidget, TextWidget } from 'react-native-android-widget';
+
+interface CounterWidgetProps {
+  count: number;
+}
+
+export function CounterWidget({ count = 0 }: CounterWidgetProps) {
+  return (
+    <FlexWidget
+      openApp
+      clickActionData={{ screenName: 'CounterScreen' }}
+      style={{
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#FFFFFF',
+        height: 'match_parent',
+        width: 'match_parent',
+        borderRadius: 32,
+        flex: 1,
+        flexDirection: 'row',
+        flexGap: 48,
+      }}
+    >
+      <FlexWidget
+        style={{
+          height: 'wrap_content',
+          width: 48,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+        clickAction="DECREMENT"
+        clickActionData={{ value: count }}
+      >
+        <TextWidget style={{ fontSize: 48 }} text="-" />
+      </FlexWidget>
+      <TextWidget style={{ fontSize: 48 }} text={`${count}`} />
+      <FlexWidget
+        style={{
+          height: 'wrap_content',
+          width: 48,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+        clickAction="INCREMENT"
+        clickActionData={{ value: count }}
+      >
+        <TextWidget style={{ fontSize: 48 }} text="+" />
+      </FlexWidget>
+    </FlexWidget>
+  );
+}
+```
+
+__Limitation:__ Only work when app is killed.

--- a/docs/docs/get-clickactiondata-when-open-app.md
+++ b/docs/docs/get-clickactiondata-when-open-app.md
@@ -87,7 +87,6 @@ const Stack = createNativeStackNavigator<ExampleScreens>();
 export function App({ clickActionData }: Props) {
   const navRef = useNavigationContainerRef<ExampleScreens>();
   const [isReady, setIsReady] = useState(false);
-  console.log(clickActionData);
 
   useEffect(() => {
     // Navigate to `screenName` defined inside `clickActionData` of widget

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -58,6 +58,10 @@ const sidebars = {
     },
     {
       type: 'doc',
+      id: 'get-clickactiondata-when-open-app',
+    },
+    {
+      type: 'doc',
       id: 'limitations',
     },
   ],

--- a/example/android/app/src/main/java/com/androidwidgetexample/MainActivity.java
+++ b/example/android/app/src/main/java/com/androidwidgetexample/MainActivity.java
@@ -1,5 +1,6 @@
 package com.androidwidgetexample;
 
+import android.os.Bundle;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
@@ -30,6 +31,23 @@ public class MainActivity extends ReactActivity {
             DefaultNewArchitectureEntryPoint.getFabricEnabled(), // fabricEnabled
             // If you opted-in for the New Architecture, we enable Concurrent React (i.e. React 18).
             DefaultNewArchitectureEntryPoint.getConcurrentReactEnabled() // concurrentRootEnabled
-        );
+        ) {
+            private Bundle mInitialProps = null;
+
+            @Override
+            protected void onCreate(Bundle savedInstanceState) {
+                Bundle bundle = getIntent().getExtras();
+                if (bundle != null && bundle.containsKey("clickActionData")) {
+                    mInitialProps = new Bundle();
+                    mInitialProps.putBundle("clickActionData", bundle.getBundle("clickActionData"));
+                }
+                super.onCreate(null);
+            }
+
+            @Override
+            protected Bundle getLaunchOptions() {
+                return mInitialProps;
+            }
+        };
     }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/runtime": "^7.20.0",
+    "@tsconfig/react-native": "^2.0.3",
     "babel-plugin-module-resolver": "^4.1.0",
     "metro-react-native-babel-preset": "^0.73.7"
   }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,9 @@
-import { NavigationContainer } from '@react-navigation/native';
+import {
+  NavigationContainer,
+  useNavigationContainerRef,
+} from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import * as React from 'react';
+import React, { useEffect, useState } from 'react';
 import { BorderScreen } from './screens/BorderScreen';
 import { CounterScreen } from './screens/CounterScreen';
 import { FlexScreen } from './screens/FlexScreen';
@@ -12,11 +15,27 @@ import { ResizableMusicWidgetPreviewScreen } from './screens/widget-preview/Resi
 import { RotatedWidgetPreviewScreen } from './screens/widget-preview/RotatedWidgetPreviewScreen';
 import { ShopifyWidgetPreviewScreen } from './screens/widget-preview/ShopifyWidgetPreviewScreen';
 
+type Props = {
+  clickActionData: {
+    screenName: keyof ExampleScreens;
+  };
+};
+
 const Stack = createNativeStackNavigator<ExampleScreens>();
 
-export function App() {
+export function App({ clickActionData }: Props) {
+  const navRef = useNavigationContainerRef<ExampleScreens>();
+  const [isReady, setIsReady] = useState(false);
+  console.log(clickActionData);
+
+  useEffect(() => {
+    if (isReady && clickActionData && navRef) {
+      navRef.navigate(clickActionData.screenName);
+    }
+  }, [clickActionData, isReady, navRef]);
+
   return (
-    <NavigationContainer>
+    <NavigationContainer ref={navRef} onReady={() => setIsReady(true)}>
       <Stack.Navigator>
         <Stack.Screen
           name="ListScreen"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -26,7 +26,6 @@ const Stack = createNativeStackNavigator<ExampleScreens>();
 export function App({ clickActionData }: Props) {
   const navRef = useNavigationContainerRef<ExampleScreens>();
   const [isReady, setIsReady] = useState(false);
-  console.log(clickActionData);
 
   useEffect(() => {
     if (isReady && clickActionData && navRef) {

--- a/example/src/widgets/CounterWidget.tsx
+++ b/example/src/widgets/CounterWidget.tsx
@@ -9,6 +9,8 @@ interface CounterWidgetProps {
 export function CounterWidget({ count = 0 }: CounterWidgetProps) {
   return (
     <FlexWidget
+      openApp
+      clickActionData={{ screenName: 'CounterScreen' }}
       style={{
         justifyContent: 'center',
         alignItems: 'center',

--- a/example/src/widgets/CounterWidget.tsx
+++ b/example/src/widgets/CounterWidget.tsx
@@ -33,7 +33,7 @@ export function CounterWidget({ count = 0 }: CounterWidgetProps) {
       >
         <TextWidget style={{ fontSize: 48 }} text="-" />
       </FlexWidget>
-      <TextWidget style={{ fontSize: 48 }} text={`${count}`} />
+      <TextWidget openApp style={{ fontSize: 48 }} text={`${count}`} />
       <FlexWidget
         style={{
           height: 'wrap_content',

--- a/example/src/widgets/FitnessWidget.tsx
+++ b/example/src/widgets/FitnessWidget.tsx
@@ -112,6 +112,7 @@ function Activity() {
   return (
     <FlexWidget
       openApp
+      clickActionData={{ screenName: 'FitnessWidgetPreviewScreen' }}
       style={{
         height: 'match_parent',
         width: 'match_parent',
@@ -162,6 +163,7 @@ function StepsHistory() {
   return (
     <FlexWidget
       openApp
+      clickActionData={{ screenName: 'FitnessWidgetPreviewScreen' }}
       style={{
         height: 'match_parent',
         width: 'match_parent',

--- a/example/src/widgets/FitnessWidget.tsx
+++ b/example/src/widgets/FitnessWidget.tsx
@@ -46,6 +46,7 @@ function StepsWalked() {
   return (
     <FlexWidget
       openApp
+      clickActionData={{ screenName: 'FitnessWidgetPreviewScreen' }}
       style={{
         flexDirection: 'column',
         height: 'match_parent',

--- a/example/src/widgets/FitnessWidget.tsx
+++ b/example/src/widgets/FitnessWidget.tsx
@@ -45,6 +45,7 @@ function ActionSelector({ isActive, iconName }: ActionSelectorProps) {
 function StepsWalked() {
   return (
     <FlexWidget
+      openApp
       style={{
         flexDirection: 'column',
         height: 'match_parent',
@@ -109,6 +110,7 @@ function StepsWalked() {
 function Activity() {
   return (
     <FlexWidget
+      openApp
       style={{
         height: 'match_parent',
         width: 'match_parent',
@@ -158,6 +160,7 @@ function Activity() {
 function StepsHistory() {
   return (
     <FlexWidget
+      openApp
       style={{
         height: 'match_parent',
         width: 'match_parent',

--- a/example/src/widgets/ResizableMusicWidget.tsx
+++ b/example/src/widgets/ResizableMusicWidget.tsx
@@ -72,7 +72,7 @@ function AlbumArt({
   overlayGradientOrientation,
 }: AlbumArtProps) {
   return (
-    <OverlapWidget style={{ height, width }}>
+    <OverlapWidget openApp style={{ height, width }}>
       <ImageWidget
         image={song.albumArt}
         imageWidth={width}

--- a/example/src/widgets/ResizableMusicWidget.tsx
+++ b/example/src/widgets/ResizableMusicWidget.tsx
@@ -72,7 +72,11 @@ function AlbumArt({
   overlayGradientOrientation,
 }: AlbumArtProps) {
   return (
-    <OverlapWidget openApp style={{ height, width }}>
+    <OverlapWidget
+      openApp
+      clickActionData={{ screenName: 'ResizableMusicWidgetPreviewScreen' }}
+      style={{ height, width }}
+    >
       <ImageWidget
         image={song.albumArt}
         imageWidth={width}

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1225,6 +1225,11 @@
   dependencies:
     "@sinonjs/commons" "^2.0.0"
 
+"@tsconfig/react-native@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/react-native/-/react-native-2.0.3.tgz#79ad8efc6d3729152da6cb23725b6c364a7349b2"
+  integrity sha512-jE58snEKBd9DXfyR4+ssZmYJ/W2mOSnNrvljR0aLyQJL9JKX6vlWELHkRjb3HBbcM9Uy0hZGijXbqEAjOERW2A==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"

--- a/src/widgets/utils/click-action.ts
+++ b/src/widgets/utils/click-action.ts
@@ -3,6 +3,7 @@ import type { CommonInternalProps } from './common-internal.props';
 export interface ClickActionProps {
   clickAction?: string;
   clickActionData?: Record<string, unknown>;
+  openApp?: boolean;
 }
 
 export function convertClickAction(
@@ -13,7 +14,11 @@ export function convertClickAction(
       ? {
           clickAction: props.clickAction,
           clickActionData: props.clickActionData ?? {},
+          openApp: props.openApp,
         }
-      : {}),
+      : {
+          openApp: props.openApp,
+        }
+      ),
   };
 }

--- a/src/widgets/utils/click-action.ts
+++ b/src/widgets/utils/click-action.ts
@@ -17,8 +17,8 @@ export function convertClickAction(
           openApp: props.openApp,
         }
       : {
+          clickActionData: props.clickActionData ?? {},
           openApp: props.openApp,
-        }
-      ),
+        }),
   };
 }

--- a/src/widgets/utils/common-internal.props.ts
+++ b/src/widgets/utils/common-internal.props.ts
@@ -4,6 +4,7 @@ export interface CommonInternalProps {
   weight?: number;
   clickAction?: string;
   clickActionData?: Record<string, unknown>;
+  openApp?: boolean;
   /**
    * #RRGGBB or #AARRGGBB
    */


### PR DESCRIPTION
I add `openApp?: boolean` to open app when press primitive.
Reason for this feature is, I used `rn-openapp` to open app when `WIDGET_CLICK`, but it didn't work if app was killed.

~~It needs improvement: if you set `openApp` at parent component, then you can't press children. I'm not a pro native developer, I have no idea how to fix it.
Example: CounterWidget, set `openApp` for root component, you can't press `+` or `-`~~ Resolved with v0.3.1