### PR TITLE
docs: Update documentation to include hints re async code

### DIFF
--- a/docs/docs/api/register-widget-task-handler.md
+++ b/docs/docs/api/register-widget-task-handler.md
@@ -50,6 +50,17 @@ export async function widgetTaskHandler(props: WidgetTaskHandlerProps) {
 
 We use `nameToWidget` to map from the **name** to the component defining the widget (useful if we have multiple widgets). There are other ways to achieve this.
 
+This file is also where you can execute regular JS code, include asynchronous operations, such as fetching data from API:
+```js title="widget-task-handler.ts"
+// ...
+case 'WIDGET_CLICK':
+  if (props.clickAction === 'refresh') {
+    const data = await fetch('https://example.com/api').then((response) => response.json());
+    props.renderWidget(<Widget title={data.title} />);
+  }
+  break;
+```
+
 ## Register widget task handler
 
 In the main `index.js` (or `index.ts`, `index.tsx`) file for our app, when we register the main component, register the widget task handler.


### PR DESCRIPTION
I wasn't sure how to refresh the widget with the data fetched from the API, so I opened an [issue](https://github.com/sAleksovski/react-native-android-widget/issues/15) to get some help. It turns out it's pretty straightforward and should be done in the `widget-task-handler.ts` file. 
I thought that having this documented with an example might be useful for other devs coming across this library.