### PR TITLE
chore: add targetCell values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `targetCellWidth` and `targetCellHeight` options in config plugin
+
 ## [0.13.1] - 2024-04-27
 
 ### Fixed

--- a/app.plugin.ts
+++ b/app.plugin.ts
@@ -384,7 +384,7 @@ ${
 }
 ${
   widget.targetCellHeight
-    ? `    android:targetCellWidth="${widget.targetCellHeight}"`
+    ? `    android:targetCellHeight="${widget.targetCellHeight}"`
     : ''
 }
 ${

--- a/app.plugin.ts
+++ b/app.plugin.ts
@@ -28,6 +28,8 @@ export interface Widget {
   description?: string;
   minWidth: `${number}dp`;
   minHeight: `${number}dp`;
+  targetCellWidth?: number;
+  targetCellHeight?: number;
   maxResizeWidth?: `${number}dp`;
   maxResizeHeight?: `${number}dp`;
   previewImage?: ResourcePath;
@@ -375,6 +377,16 @@ function withWidgetProviderXml(
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:minWidth="${widget.minWidth}"
     android:minHeight="${widget.minHeight}"
+${
+  widget.targetCellWidth
+    ? `    android:targetCellWidth="${widget.targetCellWidth}"`
+    : ''
+}
+${
+  widget.targetCellHeight
+    ? `    android:targetCellWidth="${widget.targetCellHeight}"`
+    : ''
+}
 ${
   widget.maxResizeWidth
     ? `    android:maxResizeWidth="${widget.maxResizeWidth}"`

--- a/docs/docs/tutorial/make-widget-configurable.md
+++ b/docs/docs/tutorial/make-widget-configurable.md
@@ -54,6 +54,9 @@ In the widget provider we created, add `configure` and `widgetFeatures` properti
     android:minWidth="320dp"
     android:minHeight="120dp"
 
+    android:targetCellWidth="5"
+    android:targetCellHeight="2"
+
     android:updatePeriodMillis="0"
 
     android:initialLayout="@layout/rn_widget"
@@ -124,6 +127,8 @@ const widgetConfig: WithAndroidWidgetsParams = {
       label: 'My Hello Widget',
       minWidth: '320dp',
       minHeight: '120dp',
+      targetCellWidth: 5,
+      targetCellHeight: 2,
       description: 'This is my first widget',
       previewImage: './assets/widget-preview/hello.png',
       updatePeriodMillis: 1800000,

--- a/docs/docs/tutorial/register-widget-expo.md
+++ b/docs/docs/tutorial/register-widget-expo.md
@@ -43,6 +43,11 @@ const widgetConfig: WithAndroidWidgetsParams = {
       label: 'My Hello Widget', // Label shown in the widget picker
       minWidth: '320dp',
       minHeight: '120dp',
+      // This means the widget's default size is 5x2 cells, as specified by the targetCellWidth and targetCellHeight attributes.
+      // Or 320×120dp, as specified by minWidth and minHeight for devices running Android 11 or lower.
+      // If defined, targetCellWidth,targetCellHeight attributes are used instead of minWidth or minHeight.
+      targetCellWidth: 5,
+      targetCellHeight: 2,
       description: 'This is my first widget', // Description shown in the widget picker
       previewImage: './assets/widget-preview/hello.png', // Path to widget preview image
 

--- a/src/config-plugin.type.ts
+++ b/src/config-plugin.type.ts
@@ -15,6 +15,8 @@ export interface Widget {
   description?: string;
   minWidth: `${number}dp`;
   minHeight: `${number}dp`;
+  targetCellWidth?: number;
+  targetCellHeight?: number;
   maxResizeWidth?: `${number}dp`;
   maxResizeHeight?: `${number}dp`;
   previewImage?: ResourcePath;


### PR DESCRIPTION
https://developer.android.com/develop/ui/views/appwidgets/layouts#anatomy_determining_size

- [targetCellWidth](https://developer.android.com/reference/android/appwidget/AppWidgetProviderInfo#targetCellWidth) and [targetCellHeight](https://developer.android.com/reference/android/appwidget/AppWidgetProviderInfo#targetCellHeight) are more reliable and easy to configure compared to `minWidth or minHeight`. According to docs , **If defined, these attributes are used instead of minWidth or minHeight.**