### PR TITLE
fix: handle null bitmap in ImageWidget

### DIFF
--- a/android/src/main/java/com/reactnativeandroidwidget/builder/widget/ImageWidget.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/builder/widget/ImageWidget.java
@@ -42,6 +42,9 @@ public class ImageWidget extends BaseWidget<ImageView> {
     private Bitmap getBitmapFromURL(String src, int width, int height) {
         try {
             Bitmap bitmap = ResourceUtils.getBitmap(appContext, src);
+            if (bitmap == null) {
+                return null;
+            }
             return Bitmap.createScaledBitmap(bitmap, width, height, true);
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Fix error
[java.lang.NullPointerException: Attempt to invoke virtual method 'int android.graphics.Bitmap.getWidth()' on a null object reference]
