### PR TITLE
feat: add packageName and receiverName to Widget interface for improved widget stability

### DIFF
--- a/app.plugin.ts
+++ b/app.plugin.ts
@@ -19,6 +19,16 @@ export interface Widget {
    */
   name: string;
   /**
+   * Custom Java package name for the widget's AppWidgetProvider.
+   * Keep stable across app updates to prevent widget removal.
+   */
+  packageName?: string;
+  /**
+   * Name of the BroadcastReceiver class handling the widget.
+   * Keep stable across app updates to prevent widget removal.
+   */
+  receiverName?: string;
+  /**
    * Label that will be shown in widget picker
    */
   label?: string;
@@ -212,16 +222,16 @@ function withWidgetReceiver(
   widget: Widget
 ): void {
   mainApplication.receiver = mainApplication.receiver ?? [];
-
+  const receiverName = widget.receiverName ?? `.widget.${widget.name}`;
   const alreadyAdded = mainApplication.receiver.some(
-    (service) => service.$['android:name'] === `.widget.${widget.name}`
+    (service) => service.$['android:name'] === receiverName
   );
 
   if (alreadyAdded) return;
 
   mainApplication.receiver?.push({
     '$': {
-      'android:name': `.widget.${widget.name}`,
+      'android:name': receiverName,
       'android:exported': 'false',
       'android:label': `${widget.label ?? widget.name}`,
     } as any,
@@ -344,8 +354,8 @@ function withWidgetProviderClass(
   );
 
   const javaFilePath = path.join(widgetPackagePath, `/${widget.name}.java`);
-
-  const data = `package ${config.android?.package}.widget;
+  const packageName = widget.packageName ?? `${config.android?.package}.widget`;
+  const data = `package ${packageName};
 
 import com.reactnativeandroidwidget.RNWidgetProvider;
 


### PR DESCRIPTION
#### Summary

This PR enhances the `app.plugin.ts` to allow customization of the widget's `packageName` and `receiverName` via configuration options. This ensures that widgets remain persistent on the user's home screen after app updates.

#### Background

Android identifies widgets based on their `AppWidgetProvider` class name, package name, and receiver name. Changing any of these identifiers can lead to the system treating the widget as new, causing existing widgets to be removed from the home screen upon app updates. While the current implementation supports custom class names through the `widgetName` configuration, it lacks options for customizing the package and receiver names. [Avoid changing the package name or class name of your AppWidgetProvider](https://arkadiuszchmura.com/posts/do-not-change-the-package-name-or-class-name-of-your-app-widget-provider/)

#### Changes Made

* Introduced a `packageName` option in the widget configuration to specify a custom package name.
* Introduced a `receiverName` option to define a custom receiver name in the `AndroidManifest.xml`.
* Updated `app.plugin.ts` to utilize these new configuration options when generating the widget's manifest and related files.