### PR TITLE
fix: run widget updates as expedited work so they aren't deferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Widget updates (add / resize / click) were deferred by WorkManager when the app was in the background, so widgets often only refreshed after the app was opened. They now run as expedited work on Android 12+ (API 31+), falling back to a regular request when the expedited quota is exhausted.
+
 ## [0.20.3] - 2026-05-02
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- Widget updates (add / resize / click) were deferred by WorkManager when the app was in the background, so widgets often only refreshed after the app was opened. They now run as expedited work on Android 12+ (API 31+), falling back to a regular request when the expedited quota is exhausted.
+- Use expedited WorkManager requests for widget background tasks on Android 12+ to reduce delays when the app is in the background, with fallback to regular work when expedited quota is exhausted.
 
 ## [0.20.3] - 2026-05-02
 

--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidgetJsCommunication.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidgetJsCommunication.java
@@ -28,21 +28,8 @@ public class RNWidgetJsCommunication {
             new OneTimeWorkRequest.Builder(RNWidgetBackgroundTaskWorker.class)
                 .setInputData(data);
 
-        // Widget updates are user-visible and usually user-initiated (adding/resizing a widget, or a
-        // click that maps to WIDGET_CLICK), so they should run as soon as possible. A plain
-        // OneTimeWorkRequest is deferrable work: when the app is not in the foreground WorkManager can
-        // hold it back (Doze / App Standby / batching), which is why widgets can appear to only refresh
-        // once the host app is opened. Requesting an expedited job lets the system run the task
-        // immediately when possible. See https://github.com/sAleksovski/react-native-android-widget/issues/145
-        //
-        // Expedited work is only requested on API 31+. There, expedited jobs are backed by JobScheduler
-        // and do not require a foreground service. On older versions WorkManager backs expedited work with
-        // a foreground service, which needs the worker to implement getForegroundInfo() (see
-        // ListenableWorker#getForegroundInfoAsync) — RNWidgetBackgroundTaskWorker does not, so we keep the
-        // existing deferrable behavior below API 31 to avoid the resulting IllegalStateException.
-        //
-        // RUN_AS_NON_EXPEDITED_WORK_REQUEST makes the request fall back to a regular deferrable job once
-        // the app's (quota-limited) expedited execution budget is exhausted, so enqueue never fails.
+        // Reduce background scheduling delays on Android 12+.
+        // Falls back to regular work if expedited quota is exhausted.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             builder.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST);
         }

--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidgetJsCommunication.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidgetJsCommunication.java
@@ -1,10 +1,12 @@
 package com.reactnativeandroidwidget;
 
 import android.content.Context;
+import android.os.Build;
 
 import androidx.work.Data;
 import androidx.work.ExistingWorkPolicy;
 import androidx.work.OneTimeWorkRequest;
+import androidx.work.OutOfQuotaPolicy;
 import androidx.work.WorkManager;
 
 import java.util.concurrent.TimeUnit;
@@ -22,14 +24,32 @@ public class RNWidgetJsCommunication {
     protected static void startBackgroundTask(Context context, Data data) {
         workManagerWorkaround(context);
 
-        OneTimeWorkRequest headlessJsTaskWorkRequest =
+        OneTimeWorkRequest.Builder builder =
             new OneTimeWorkRequest.Builder(RNWidgetBackgroundTaskWorker.class)
-                .setInputData(data)
-                .build();
+                .setInputData(data);
+
+        // Widget updates are user-visible and usually user-initiated (adding/resizing a widget, or a
+        // click that maps to WIDGET_CLICK), so they should run as soon as possible. A plain
+        // OneTimeWorkRequest is deferrable work: when the app is not in the foreground WorkManager can
+        // hold it back (Doze / App Standby / batching), which is why widgets can appear to only refresh
+        // once the host app is opened. Requesting an expedited job lets the system run the task
+        // immediately when possible. See https://github.com/sAleksovski/react-native-android-widget/issues/145
+        //
+        // Expedited work is only requested on API 31+. There, expedited jobs are backed by JobScheduler
+        // and do not require a foreground service. On older versions WorkManager backs expedited work with
+        // a foreground service, which needs the worker to implement getForegroundInfo() (see
+        // ListenableWorker#getForegroundInfoAsync) — RNWidgetBackgroundTaskWorker does not, so we keep the
+        // existing deferrable behavior below API 31 to avoid the resulting IllegalStateException.
+        //
+        // RUN_AS_NON_EXPEDITED_WORK_REQUEST makes the request fall back to a regular deferrable job once
+        // the app's (quota-limited) expedited execution budget is exhausted, so enqueue never fails.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            builder.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST);
+        }
 
         WorkManager
             .getInstance(context)
-            .enqueue(headlessJsTaskWorkRequest);
+            .enqueue(builder.build());
     }
 
     // `APPWIDGET_UPDATE` (`onUpdate`) method is called when the WorkManager queue is empty.


### PR DESCRIPTION
## Summary

Widget updates (`WIDGET_ADDED` / `WIDGET_RESIZED` / `WIDGET_CLICK`, and `requestWidgetUpdate`)
are enqueued from `RNWidgetJsCommunication.startBackgroundTask` as a plain, deferrable
`OneTimeWorkRequest`. On lenient schedulers this already runs promptly, so it's not a universal
delay — but deferrable work *can* be held back on aggressive OEM battery managers (Samsung,
Xiaomi, etc.) and under Doze / App Standby, where these user-visible, user-initiated updates
then feel laggy or seem to only refresh once the app is opened.

## Change

Request an expedited job for the background task so the system runs it as soon as possible:

```java
if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
    builder.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST);
}
```

Design notes:

- Gated to API 31+. There, expedited jobs are backed by JobScheduler and need no foreground
  service. On older versions WorkManager backs expedited work with a foreground service, which
  requires the worker to implement `getForegroundInfo()` — `RNWidgetBackgroundTaskWorker` does
  not, so calling `setExpedited` there would throw `IllegalStateException`. Below API 31 the
  existing deferrable behavior is unchanged.
- `RUN_AS_NON_EXPEDITED_WORK_REQUEST` makes the request gracefully fall back to a regular
  deferrable job once the app's (quota-limited) expedited execution budget is exhausted, so
  `enqueue` never fails.
- No public API change — transparent to existing users. `work-runtime` is already `2.8.1`, which
  supports `setExpedited` (added in 2.7.0).

If you'd prefer this be opt-in (a "time-sensitive updates" flag) rather than on by default for
API 31+, I'm happy to reshape it.

## Test plan

- [ ] Add the widget with the app swiped away → it renders promptly instead of waiting for the next app open.
- [ ] Resize the widget with the app backgrounded → re-render is prompt.
- [ ] Tap a `WIDGET_CLICK` action with the app backgrounded → the headless handler runs without the earlier delay.
- [ ] API < 31 device → behavior unchanged, no crash.

## Note on the reference

#145 is primarily about `ImageWidget` letterboxing; this deferred-updates behavior was raised in
a comment there, so I'm referencing it for context rather than closing it. Glad to open a
dedicated issue for it if you'd rather track it separately.

Refs #145
