### PR TITLE
fix: round the click ripple to match a clickable view's borderRadius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- The press highlight (ripple) of a clickable view is drawn on a separate overlay, so it ignored the view's `borderRadius` and always appeared as a rectangle over rounded buttons/cards. It now follows the clickable view's `borderRadius` on Android 12+ (API 31+) via `setViewOutlinePreferredRadius`; views with square corners and older versions are unchanged.
+
 ## [0.20.3] - 2026-05-02
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- The press highlight (ripple) of a clickable view is drawn on a separate overlay, so it ignored the view's `borderRadius` and always appeared as a rectangle over rounded buttons/cards. It now follows the clickable view's `borderRadius` on Android 12+ (API 31+) via `setViewOutlinePreferredRadius`; views with square corners and older versions are unchanged.
+- Match clickable view ripple corners to uniform `borderRadius` on Android 12+.
 
 ## [0.20.3] - 2026-05-02
 

--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidget.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidget.java
@@ -180,18 +180,7 @@ public class RNWidget {
 
         clickableRemoteView.setInt(R.id.rn_widget_clickable_area, "setMinimumHeight", offsetViewBounds.height());
 
-        // Round the press-highlight to match the clickable view's own corner radius. The ripple lives
-        // on THIS separate overlay (rn_widget_clickable_area, background = ?attr/selectableItemBackground)
-        // laid over the view's bounds — it is NOT the rendered widget bitmap, so a rounded view (e.g. a
-        // pill-shaped button or a card with a borderRadius) otherwise gets a RECTANGULAR highlight on
-        // press. Rounding needs BOTH calls (API 31+): setViewOutlinePreferredRadius gives the overlay a
-        // round-rect OutlineProvider, and setClipToOutline=true makes the view actually clip its drawing
-        // (including the ripple background) to that outline — an outline on its own does not clip. This
-        // mirrors AndroidX RemoteViewsCompat (setViewOutlinePreferredRadius + setViewClipToOutline, both
-        // @RequiresApi(31)); setBoolean invokes View#setClipToOutline directly, avoiding a new dependency.
-        // Touch bounds are unaffected (the outline only clips drawing), so the corners stay tappable.
-        // Views with square corners (radius 0) are left untouched, and below API 31 the highlight remains
-        // rectangular.
+        // The clickable overlay draws its own ripple, so match it to the view's radius when supported
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && clickableView.getBorderRadius() > 0f) {
             clickableRemoteView.setViewOutlinePreferredRadius(
                 R.id.rn_widget_clickable_area,
@@ -311,6 +300,7 @@ public class RNWidget {
                 collectionViewMap.putInt("width", offsetViewBounds.width());
                 collectionViewMap.putString("clickAction", clickableView.getClickAction());
                 collectionViewMap.putBundle("clickActionData", Arguments.toBundle(clickableView.getClickActionData()));
+                collectionViewMap.putFloat("borderRadius", clickableView.getBorderRadius());
                 
                 // Add clickable area accessibility label if available
                 if (clickableView.getAccessibilityLabel() != null) {
@@ -378,6 +368,7 @@ public class RNWidget {
         clickableViewMap.putDouble("height", RNWidgetUtil.pxToDp(appContext, offsetViewBounds.height()));
         clickableViewMap.putString("clickAction", clickableView.getClickAction());
         clickableViewMap.putMap("clickActionData", Arguments.makeNativeMap(clickableView.getClickActionData().toHashMap()));
+        clickableViewMap.putDouble("borderRadius", clickableView.getBorderRadius());
 
         return clickableViewMap;
     }
@@ -443,6 +434,7 @@ public class RNWidget {
             collectionViewMap.putDouble("height", RNWidgetUtil.pxToDp(appContext, offsetViewBounds.height()));
             collectionViewMap.putString("clickAction", clickableView.getClickAction());
             collectionViewMap.putMap("clickActionData", Arguments.makeNativeMap(clickableView.getClickActionData().toHashMap()));
+            collectionViewMap.putDouble("borderRadius", clickableView.getBorderRadius());
 
             clickableAreas.pushMap(collectionViewMap);
         }

--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidget.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidget.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Base64;
+import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RemoteViews;
@@ -178,6 +179,22 @@ public class RNWidget {
         );
 
         clickableRemoteView.setInt(R.id.rn_widget_clickable_area, "setMinimumHeight", offsetViewBounds.height());
+
+        // Round the press-highlight to match the clickable view's own corner radius. The ripple lives
+        // on THIS separate overlay (rn_widget_clickable_area, background = ?attr/selectableItemBackground)
+        // laid over the view's bounds — it is NOT the rendered widget bitmap, so a rounded view (e.g. a
+        // pill-shaped button or a card with a borderRadius) otherwise gets a RECTANGULAR highlight on
+        // press. setViewOutlinePreferredRadius (API 31+) clips the overlay — and, via clipToOutline, its
+        // ripple — to a rounded outline that matches the view. Touch bounds are unaffected (the outline
+        // only clips drawing), so the corners stay tappable. Views with square corners (radius 0) are
+        // left untouched, and below API 31 the highlight remains rectangular.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && clickableView.getBorderRadius() > 0f) {
+            clickableRemoteView.setViewOutlinePreferredRadius(
+                R.id.rn_widget_clickable_area,
+                clickableView.getBorderRadius(),
+                TypedValue.COMPLEX_UNIT_DIP
+            );
+        }
 
         if (clickableView.getAccessibilityLabel() != null) {
             clickableRemoteView.setContentDescription(R.id.rn_widget_clickable_area, clickableView.getAccessibilityLabel());

--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidget.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidget.java
@@ -184,16 +184,21 @@ public class RNWidget {
         // on THIS separate overlay (rn_widget_clickable_area, background = ?attr/selectableItemBackground)
         // laid over the view's bounds — it is NOT the rendered widget bitmap, so a rounded view (e.g. a
         // pill-shaped button or a card with a borderRadius) otherwise gets a RECTANGULAR highlight on
-        // press. setViewOutlinePreferredRadius (API 31+) clips the overlay — and, via clipToOutline, its
-        // ripple — to a rounded outline that matches the view. Touch bounds are unaffected (the outline
-        // only clips drawing), so the corners stay tappable. Views with square corners (radius 0) are
-        // left untouched, and below API 31 the highlight remains rectangular.
+        // press. Rounding needs BOTH calls (API 31+): setViewOutlinePreferredRadius gives the overlay a
+        // round-rect OutlineProvider, and setClipToOutline=true makes the view actually clip its drawing
+        // (including the ripple background) to that outline — an outline on its own does not clip. This
+        // mirrors AndroidX RemoteViewsCompat (setViewOutlinePreferredRadius + setViewClipToOutline, both
+        // @RequiresApi(31)); setBoolean invokes View#setClipToOutline directly, avoiding a new dependency.
+        // Touch bounds are unaffected (the outline only clips drawing), so the corners stay tappable.
+        // Views with square corners (radius 0) are left untouched, and below API 31 the highlight remains
+        // rectangular.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && clickableView.getBorderRadius() > 0f) {
             clickableRemoteView.setViewOutlinePreferredRadius(
                 R.id.rn_widget_clickable_area,
                 clickableView.getBorderRadius(),
                 TypedValue.COMPLEX_UNIT_DIP
             );
+            clickableRemoteView.setBoolean(R.id.rn_widget_clickable_area, "setClipToOutline", true);
         }
 
         if (clickableView.getAccessibilityLabel() != null) {

--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidgetCollectionService.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidgetCollectionService.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.TypedValue;
 import android.widget.RemoteViews;
 import android.widget.RemoteViewsService;
 
@@ -115,6 +116,17 @@ class ListRemoteViewsFactory implements RemoteViewsService.RemoteViewsFactory {
         );
 
         clickableRemoteView.setInt(R.id.rn_widget_clickable_area, "setMinimumHeight", clickableArea.getInt("height"));
+
+        // The clickable overlay draws its own ripple, so match it to the view's radius when supported
+        float borderRadius = clickableArea.getFloat("borderRadius", 0f);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && borderRadius > 0f) {
+            clickableRemoteView.setViewOutlinePreferredRadius(
+                R.id.rn_widget_clickable_area,
+                borderRadius,
+                TypedValue.COMPLEX_UNIT_DIP
+            );
+            clickableRemoteView.setBoolean(R.id.rn_widget_clickable_area, "setClipToOutline", true);
+        }
 
         // Set accessibility label on clickable area if available
         if (clickableArea.getString("accessibilityLabel", null) != null) {

--- a/android/src/main/java/com/reactnativeandroidwidget/builder/ClickableView.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/builder/ClickableView.java
@@ -10,17 +10,25 @@ public class ClickableView implements Comparable<ClickableView> {
     private final String clickAction;
     private final ReadableMap clickActionData;
     private final String accessibilityLabel;
+    // Corner radius (dp) of the clickable view, so the press-highlight overlay can be rounded to match
+    // it (see RNWidget#addClickableArea). 0 = square corners (the default / previous behavior).
+    private final float borderRadius;
 
     public ClickableView(String id, View view, String clickAction, ReadableMap clickActionData) {
-        this(id, view, clickAction, clickActionData, null);
+        this(id, view, clickAction, clickActionData, null, 0f);
     }
 
     public ClickableView(String id, View view, String clickAction, ReadableMap clickActionData, String accessibilityLabel) {
+        this(id, view, clickAction, clickActionData, accessibilityLabel, 0f);
+    }
+
+    public ClickableView(String id, View view, String clickAction, ReadableMap clickActionData, String accessibilityLabel, float borderRadius) {
         this.id = id;
         this.view = view;
         this.clickAction = clickAction;
         this.clickActionData = clickActionData;
         this.accessibilityLabel = accessibilityLabel;
+        this.borderRadius = borderRadius;
     }
 
     public String getId() {
@@ -41,6 +49,10 @@ public class ClickableView implements Comparable<ClickableView> {
 
     public String getAccessibilityLabel() {
         return accessibilityLabel;
+    }
+
+    public float getBorderRadius() {
+        return borderRadius;
     }
 
     @Override

--- a/android/src/main/java/com/reactnativeandroidwidget/builder/ClickableView.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/builder/ClickableView.java
@@ -10,8 +10,6 @@ public class ClickableView implements Comparable<ClickableView> {
     private final String clickAction;
     private final ReadableMap clickActionData;
     private final String accessibilityLabel;
-    // Corner radius (dp) of the clickable view, so the press-highlight overlay can be rounded to match
-    // it (see RNWidget#addClickableArea). 0 = square corners (the default / previous behavior).
     private final float borderRadius;
 
     public ClickableView(String id, View view, String clickAction, ReadableMap clickActionData) {

--- a/android/src/main/java/com/reactnativeandroidwidget/builder/WidgetFactory.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/builder/WidgetFactory.java
@@ -91,17 +91,29 @@ public class WidgetFactory {
         }
 
         if (config.getMap("props").hasKey("clickAction")) {
+            ReadableMap props = config.getMap("props");
             String accessibilityLabel = null;
-            if (config.getMap("props").hasKey("accessibilityLabel")) {
-                accessibilityLabel = config.getMap("props").getString("accessibilityLabel");
+            if (props.hasKey("accessibilityLabel")) {
+                accessibilityLabel = props.getString("accessibilityLabel");
+            }
+            // Carry the view's corner radius (dp) so its press-highlight overlay can be rounded to
+            // match (see RNWidget#addClickableArea). borderRadius is serialised as a per-corner map;
+            // widgets typically use a uniform radius, so topLeft represents the shape. Absent/null → 0.
+            float clickBorderRadius = 0f;
+            if (props.hasKey("borderRadius") && !props.isNull("borderRadius")) {
+                ReadableMap borderRadius = props.getMap("borderRadius");
+                if (borderRadius != null && borderRadius.hasKey("topLeft")) {
+                    clickBorderRadius = (float) borderRadius.getDouble("topLeft");
+                }
             }
             clickableViews.add(
                 new ClickableView(
                     id,
                     view,
-                    config.getMap("props").getString("clickAction"),
-                    config.getMap("props").getMap("clickActionData"),
-                    accessibilityLabel
+                    props.getString("clickAction"),
+                    props.getMap("clickActionData"),
+                    accessibilityLabel,
+                    clickBorderRadius
                 )
             );
         }

--- a/android/src/main/java/com/reactnativeandroidwidget/builder/WidgetFactory.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/builder/WidgetFactory.java
@@ -96,16 +96,6 @@ public class WidgetFactory {
             if (props.hasKey("accessibilityLabel")) {
                 accessibilityLabel = props.getString("accessibilityLabel");
             }
-            // Carry the view's corner radius (dp) so its press-highlight overlay can be rounded to
-            // match (see RNWidget#addClickableArea). borderRadius is serialised as a per-corner map;
-            // widgets typically use a uniform radius, so topLeft represents the shape. Absent/null → 0.
-            float clickBorderRadius = 0f;
-            if (props.hasKey("borderRadius") && !props.isNull("borderRadius")) {
-                ReadableMap borderRadius = props.getMap("borderRadius");
-                if (borderRadius != null && borderRadius.hasKey("topLeft")) {
-                    clickBorderRadius = (float) borderRadius.getDouble("topLeft");
-                }
-            }
             clickableViews.add(
                 new ClickableView(
                     id,
@@ -113,12 +103,32 @@ public class WidgetFactory {
                     props.getString("clickAction"),
                     props.getMap("clickActionData"),
                     accessibilityLabel,
-                    clickBorderRadius
+                    getUniformBorderRadius(props)
                 )
             );
         }
 
         return view;
+    }
+
+    private float getUniformBorderRadius(ReadableMap props) {
+        if (!props.hasKey("borderRadius") || props.isNull("borderRadius")) {
+            return 0f;
+        }
+
+        ReadableMap radius = props.getMap("borderRadius");
+        if (radius == null) {
+            return 0f;
+        }
+
+        double topLeft = radius.hasKey("topLeft") ? radius.getDouble("topLeft") : 0;
+        double topRight = radius.hasKey("topRight") ? radius.getDouble("topRight") : 0;
+        double bottomRight = radius.hasKey("bottomRight") ? radius.getDouble("bottomRight") : 0;
+        double bottomLeft = radius.hasKey("bottomLeft") ? radius.getDouble("bottomLeft") : 0;
+
+        return topLeft == topRight && topLeft == bottomRight && topLeft == bottomLeft
+            ? (float) topLeft
+            : 0f;
     }
 
     @NonNull

--- a/src/api/WidgetPreview.tsx
+++ b/src/api/WidgetPreview.tsx
@@ -267,18 +267,30 @@ function ClickableAreaButton({
         height: area.height,
       }}
     >
-      <TouchableNativeFeedback onPress={() => onClick(area)}>
-        <View
-          style={{
-            width: '100%',
-            height: '100%',
-            borderColor: 'red',
-            borderWidth: highlightClickableAreas ? 1 : 0,
-            borderRadius: area.borderRadius,
-            overflow: 'hidden',
-          }}
-        />
-      </TouchableNativeFeedback>
+      {/* Clip the ripple to the corners: borderRadius + overflow must WRAP the touchable (not sit on
+          its child), with an explicit bounded Ripple — the default background won't clip (RN #25342). */}
+      <View
+        style={{
+          width: '100%',
+          height: '100%',
+          borderRadius: area.borderRadius,
+          overflow: 'hidden',
+        }}
+      >
+        <TouchableNativeFeedback
+          onPress={() => onClick(area)}
+          background={TouchableNativeFeedback.Ripple('rgba(150, 150, 150, 0.35)', false)}
+        >
+          <View
+            style={{
+              width: '100%',
+              height: '100%',
+              borderColor: 'red',
+              borderWidth: highlightClickableAreas ? 1 : 0,
+            }}
+          />
+        </TouchableNativeFeedback>
+      </View>
       {highlightClickableAreas ? <ClickableAreaBorder /> : null}
     </View>
   );

--- a/src/api/WidgetPreview.tsx
+++ b/src/api/WidgetPreview.tsx
@@ -258,32 +258,43 @@ function ClickableAreaButton({
   highlightClickableAreas,
 }: ClickableAreaButtonProps) {
   return (
-    <TouchableNativeFeedback onPress={() => onClick(area)}>
-      <View
-        style={{
-          position: 'absolute',
-          left: area.left,
-          top: area.top,
-          width: area.width,
-          height: area.height,
-          borderColor: 'red',
-          borderWidth: highlightClickableAreas ? 1 : 0,
-        }}
-      >
-        {highlightClickableAreas ? <ClickableAreaBorder /> : null}
-      </View>
-    </TouchableNativeFeedback>
+    <View
+      style={{
+        position: 'absolute',
+        left: area.left,
+        top: area.top,
+        width: area.width,
+        height: area.height,
+      }}
+    >
+      <TouchableNativeFeedback onPress={() => onClick(area)}>
+        {/* borderRadius + overflow clip the press ripple to the view's rounded corners so the
+            preview matches the on-device rounded ripple (see RNWidget#addClickableArea). The
+            highlight markers live on the parent so they are not clipped. */}
+        <View
+          style={{
+            width: '100%',
+            height: '100%',
+            borderColor: 'red',
+            borderWidth: highlightClickableAreas ? 1 : 0,
+            borderRadius: area.borderRadius,
+            overflow: 'hidden',
+          }}
+        />
+      </TouchableNativeFeedback>
+      {highlightClickableAreas ? <ClickableAreaBorder /> : null}
+    </View>
   );
 }
 
 function ClickableAreaBorder() {
   return (
-    <>
+    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
       <View style={styles.clickableHighlightTopLeft} />
       <View style={styles.clickableHighlightTopRight} />
       <View style={styles.clickableHighlightBottomLeft} />
       <View style={styles.clickableHighlightBottomRight} />
-    </>
+    </View>
   );
 }
 

--- a/src/api/WidgetPreview.tsx
+++ b/src/api/WidgetPreview.tsx
@@ -268,9 +268,6 @@ function ClickableAreaButton({
       }}
     >
       <TouchableNativeFeedback onPress={() => onClick(area)}>
-        {/* borderRadius + overflow clip the press ripple to the view's rounded corners so the
-            preview matches the on-device rounded ripple (see RNWidget#addClickableArea). The
-            highlight markers live on the parent so they are not clipped. */}
         <View
           style={{
             width: '100%',

--- a/src/api/private.types.ts
+++ b/src/api/private.types.ts
@@ -8,6 +8,7 @@ export interface ClickableArea extends OnClick {
   top: number;
   width: number;
   height: number;
+  borderRadius: number;
 }
 
 export interface CollectionItem extends OnClick {


### PR DESCRIPTION
## Summary

Clickable views (`clickAction`) get their press feedback from a separate transparent overlay that `RNWidget.addClickableArea` lays over each view's bounds — an `rn_widget_clickable` `FrameLayout` whose background is `?android:attr/selectableItemBackground`. That overlay is a plain rectangle and is independent of the rendered widget bitmap, so when a clickable view is a rounded button or card (has a `borderRadius`), the press ripple still shows up as a **rectangle** that spills over the rounded corners.

It's a small thing but it stands out on a pill-shaped button or a rounded card, since the highlight doesn't match the shape the user sees.

## Change

Carry each clickable view's `borderRadius` through to its overlay and, on API 31+, round the overlay so the ripple follows the view's corners. This needs **two** calls: `setViewOutlinePreferredRadius` installs a round-rect `OutlineProvider`, and `setClipToOutline(true)` makes the view actually clip its drawing (including the ripple background) to that outline — an outline on its own doesn't clip:

```java
if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && clickableView.getBorderRadius() > 0f) {
    clickableRemoteView.setViewOutlinePreferredRadius(
        R.id.rn_widget_clickable_area,
        clickableView.getBorderRadius(),
        TypedValue.COMPLEX_UNIT_DIP
    );
    clickableRemoteView.setBoolean(R.id.rn_widget_clickable_area, "setClipToOutline", true);
}
```

Design notes:

- `borderRadius` is already serialized per node as a per-corner map, so `WidgetFactory` just reads `topLeft` (widgets typically use a uniform radius) and passes it into a new optional `ClickableView` field. Nothing else about how the view is built changes.
- The pairing mirrors AndroidX `RemoteViewsCompat` (`setViewOutlinePreferredRadius` + `setViewClipToOutline`, both `@RequiresApi(31)`). I use `setBoolean(..., "setClipToOutline", true)` — which invokes `View#setClipToOutline` directly, exactly like `RemoteViewsCompat` does under the hood — to avoid adding an `androidx.core` dependency.
- Touch bounds are unaffected — `clipToOutline` only clips drawing, so the full rectangle stays tappable; only the highlight is rounded.
- Gated to API 31+, where `setViewOutlinePreferredRadius` is available. Below 31 the highlight stays rectangular, exactly as today.
- Views with square corners (radius `0`) are skipped, so existing widgets are visually unchanged unless they already set a `borderRadius`.
- No public API change — it's derived automatically from the `borderRadius` already on the view.

I kept it automatic rather than adding a new prop, since it just makes the existing highlight match the shape you already described on the view. If you'd rather have it behind an opt-in prop, I'm happy to reshape it.

## Test plan

- [ ] A clickable `FlexWidget` with a `borderRadius` (e.g. a pill button) → the press ripple is rounded to the corners instead of a rectangle (API 31+).
- [ ] A clickable view without a `borderRadius` → highlight unchanged (rectangle).
- [ ] API < 31 device → behavior unchanged.
- [ ] Tapping still triggers the click near the corners (touch area unaffected).
