### PR TITLE
fix: constrain ListWidget overlay to widget bounds

### DIFF
--- a/android/src/main/java/com/reactnativeandroidwidget/RNWidget.java
+++ b/android/src/main/java/com/reactnativeandroidwidget/RNWidget.java
@@ -217,6 +217,20 @@ public class RNWidget {
 
     private void addCollectionViews(int widgetId, RemoteViews remoteWidgetView, WidgetWithViews widgetWithViews) {
         remoteWidgetView.removeAllViews(R.id.rn_widget_collection_container);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            remoteWidgetView.setViewLayoutWidth(
+                R.id.rn_widget_collection_container,
+                RNWidgetUtil.getWidgetWidth(appContext, widgetId),
+                TypedValue.COMPLEX_UNIT_DIP
+            );
+            remoteWidgetView.setViewLayoutHeight(
+                R.id.rn_widget_collection_container,
+                RNWidgetUtil.getWidgetHeight(appContext, widgetId),
+                TypedValue.COMPLEX_UNIT_DIP
+            );
+        }
+
         ViewGroup rootView = (ViewGroup) widgetWithViews.getRootView();
         List<CollectionView> collectionViews = widgetWithViews.getCollectionViews();
 


### PR DESCRIPTION
## Summary

- size the native collection container to the same dimensions used to render the widget bitmap
- prevent ListWidget rows from painting outside the visible widget surface when launcher host bounds are larger
- retain the existing behavior on Android versions below API 31

The layout change is limited to the outer collection container. List rows and their nested clickable overlays keep the same pending-intent setup and continue to render and respond correctly.

## Testing

- reproduced with a forced 14dp host/bitmap height mismatch on Android 16 with Niagara Launcher
- verified the collection terminates at the rendered widget boundary
- verified normal release rendering after removing the forced mismatch
- yarn typescript
- yarn lint (passes with three existing no-bitwise warnings)
- yarn test --runInBand
- Android SDK 36: :app:compileDebugJavaWithJavac

Fixes #151